### PR TITLE
Pump not allowed warning debug, sandbox production point support, GIANTS helper and AutoDrive support.

### DIFF
--- a/src/common/strategies/ManureSystemDockStrategy.lua
+++ b/src/common/strategies/ManureSystemDockStrategy.lua
@@ -109,10 +109,10 @@ function ManureSystemDockStrategy:onUpdate(dt)
                                 fillObject = desc.vehicle
                                 fillUnitIndex = desc.fillUnitIndex
                             end
-                        end
-
-                        if fillObject.setUsedConnectorId ~= nil then
-                            fillObject:setUsedConnectorId(connector.id)
+                        else
+                            if fillObject.setUsedConnectorId ~= nil then
+                                fillObject:setUsedConnectorId(connector.id)
+                            end
                         end
 
                         dockingArmObject:setPumpTargetObject(fillObject, fillUnitIndex)
@@ -176,6 +176,10 @@ function ManureSystemDockStrategy:getStationaryConnectorDesc(connector)
             if desc ~= nil and desc.vehicle ~= object then
                 local descConnector = desc.vehicle:getConnectorById(desc.connectorId)
                 if stationaryConnector.hasOpenManureFlow and descConnector.hasOpenManureFlow then
+                    if desc.vehicle.setUsedConnectorId ~= nil then
+                        desc.vehicle:setUsedConnectorId(desc.connectorId)
+                    end
+
                     return { vehicle = desc.vehicle, fillUnitIndex = descConnector.fillUnitIndex }, length
                 end
             end

--- a/src/placeables/specializations/ManureSystemPlaceableBase.lua
+++ b/src/placeables/specializations/ManureSystemPlaceableBase.lua
@@ -28,6 +28,7 @@ function ManureSystemPlaceableBase.registerFunctions(placeableType)
     SpecializationUtil.registerFunction(placeableType, "getCanDisableVanillaLoading", ManureSystemPlaceableBase.getCanDisableVanillaLoading)
 
     SpecializationUtil.registerFunction(placeableType, "getFillUnitFillType", ManureSystemPlaceableBase.getFillUnitFillType)
+    SpecializationUtil.registerFunction(placeableType, "getFillUnitSupportedFillTypes", ManureSystemPlaceableBase.getFillUnitSupportedFillTypes)
     SpecializationUtil.registerFunction(placeableType, "getFillUnitAllowsFillType", ManureSystemPlaceableBase.getFillUnitAllowsFillType)
     SpecializationUtil.registerFunction(placeableType, "getFillUnitFillLevel", ManureSystemPlaceableBase.getFillUnitFillLevel)
     SpecializationUtil.registerFunction(placeableType, "getFillUnitFillLevelPercentage", ManureSystemPlaceableBase.getFillUnitFillLevelPercentage)
@@ -137,6 +138,16 @@ end
 ---@return number
 function ManureSystemPlaceableBase:getFillUnitFillType(fillUnitIndex)
     return FillType.UNKNOWN
+end
+
+---@return table
+function ManureSystemPlaceableBase:getFillUnitSupportedFillTypes(fillUnitIndex)
+    local storage = self:getManureSystemStorageByIndex(fillUnitIndex)
+    if storage ~= nil then
+        return storage:getSupportedFillTypes()
+    end
+
+    return {}
 end
 
 ---@return boolean

--- a/src/placeables/specializations/ManureSystemPlaceableProductionPoint.lua
+++ b/src/placeables/specializations/ManureSystemPlaceableProductionPoint.lua
@@ -13,6 +13,10 @@ ManureSystemPlaceableProductionPoint = {}
 
 ---@return boolean
 function ManureSystemPlaceableProductionPoint.prerequisitesPresent(specializations)
+    if pdlc_pumpsAndHosesPack ~= nil and SpecializationUtil.hasSpecialization(pdlc_pumpsAndHosesPack.SandboxPlaceableProductionPoint, specializations) then
+        return true
+    end
+
     return SpecializationUtil.hasSpecialization(PlaceableProductionPoint, specializations)
 end
 
@@ -33,7 +37,7 @@ end
 
 ---@return void
 function ManureSystemPlaceableProductionPoint:onPostLoad(savegame)
-    local productionPoint = self.spec_productionPoint.productionPoint
+    local productionPoint = ManureSystemPlaceableProductionPoint.getProductionPoint(self)
     if productionPoint ~= nil then
         if self:addManureSystemStorage(productionPoint.storage) then
             productionPoint.storage.canFarmAccess = function(_, farmId)
@@ -61,8 +65,21 @@ end
 
 ---@return void
 function ManureSystemPlaceableProductionPoint:onPreDelete()
-    local productionPoint = self.spec_productionPoint.productionPoint
+    local productionPoint = ManureSystemPlaceableProductionPoint.getProductionPoint(self)
     if productionPoint ~= nil then
         self:removeManureSystemStorage(productionPoint.storage)
     end
+end
+
+---@return table | nil
+function ManureSystemPlaceableProductionPoint.getProductionPoint(self)
+    if self.spec_productionPoint ~= nil then
+        return self.spec_productionPoint.productionPoint
+    end
+
+    if self.spec_sandboxPlaceableProductionPoint ~= nil then
+        return self.spec_sandboxPlaceableProductionPoint.productionPoint
+    end
+
+    return nil
 end

--- a/src/placeables/specializations/ManureSystemPlaceableProductionPoint.lua
+++ b/src/placeables/specializations/ManureSystemPlaceableProductionPoint.lua
@@ -13,11 +13,21 @@ ManureSystemPlaceableProductionPoint = {}
 
 ---@return boolean
 function ManureSystemPlaceableProductionPoint.prerequisitesPresent(specializations)
+    if SpecializationUtil.hasSpecialization(PlaceableProductionPoint, specializations) then
+        return true
+    end
+
     if pdlc_pumpsAndHosesPack ~= nil and SpecializationUtil.hasSpecialization(pdlc_pumpsAndHosesPack.SandboxPlaceableProductionPoint, specializations) then
         return true
     end
 
-    return SpecializationUtil.hasSpecialization(PlaceableProductionPoint, specializations)
+    for _, specializationObject in ipairs(specializations) do
+        if ManureSystem.getTypeNameModType(specializationObject.className) == "PlaceableExtendedProductionPoint" then
+            return true
+        end
+    end
+
+    return false
 end
 
 ---@return void
@@ -79,6 +89,10 @@ function ManureSystemPlaceableProductionPoint.getProductionPoint(self)
 
     if self.spec_sandboxPlaceableProductionPoint ~= nil then
         return self.spec_sandboxPlaceableProductionPoint.productionPoint
+    end
+
+    if self.spec_extendedProductionPoint ~= nil then
+        return self.spec_extendedProductionPoint.productionPoint
     end
 
     return nil

--- a/src/vehicles/specializations/ManureSystemConnector.lua
+++ b/src/vehicles/specializations/ManureSystemConnector.lua
@@ -198,10 +198,10 @@ function ManureSystemConnector:getCanDischargeToObject(superFunc, dischargeNode)
                 trigger = object
             end
 
-            local sourceObjectCanDisableVanillaLoading = self.getCanDisableVanillaUnloading == nil or self:getCanDisableVanillaUnloading(targetObject, trigger)
-            local targetObjectCanDisableVanillaLoading = targetObject.getCanDisableVanillaUnloading == nil or targetObject:getCanDisableVanillaUnloading(self, trigger)
+            local sourceObjectCanDisableVanillaUnloading = self.getCanDisableVanillaUnloading == nil or self:getCanDisableVanillaUnloading(targetObject, trigger)
+            local targetObjectCanDisableVanillaUnloading = targetObject.getCanDisableVanillaUnloading == nil or targetObject:getCanDisableVanillaUnloading(self, trigger)
 
-            if sourceObjectCanDisableVanillaLoading and targetObjectCanDisableVanillaLoading then
+            if sourceObjectCanDisableVanillaUnloading and targetObjectCanDisableVanillaUnloading then
                 local pumpDirectionIn = ManureSystemPumpMotor.PUMP_DIRECTION_IN
                 local pumpDirectionOut = ManureSystemPumpMotor.PUMP_DIRECTION_OUT
 

--- a/src/vehicles/specializations/ManureSystemFillArm.lua
+++ b/src/vehicles/specializations/ManureSystemFillArm.lua
@@ -336,10 +336,10 @@ function ManureSystemFillArm:getCanDischargeToObject(superFunc, dischargeNode)
             trigger = object
         end
 
-        local sourceObjectCanDisableVanillaLoading = self.getCanDisableVanillaUnloading == nil or self:getCanDisableVanillaUnloading(targetObject, trigger)
-        local targetObjectCanDisableVanillaLoading = targetObject.getCanDisableVanillaUnloading == nil or targetObject:getCanDisableVanillaUnloading(self, trigger)
+        local sourceObjectCanDisableVanillaUnloading = self.getCanDisableVanillaUnloading == nil or self:getCanDisableVanillaUnloading(targetObject, trigger)
+        local targetObjectCanDisableVanillaUnloading = targetObject.getCanDisableVanillaUnloading == nil or targetObject:getCanDisableVanillaUnloading(self, trigger)
 
-        if sourceObjectCanDisableVanillaLoading and targetObjectCanDisableVanillaLoading then
+        if sourceObjectCanDisableVanillaUnloading and targetObjectCanDisableVanillaUnloading then
             local pumpDirectionIn = ManureSystemPumpMotor.PUMP_DIRECTION_IN
             local pumpDirectionOut = ManureSystemPumpMotor.PUMP_DIRECTION_OUT
 

--- a/src/vehicles/specializations/ManureSystemPumpMotor.lua
+++ b/src/vehicles/specializations/ManureSystemPumpMotor.lua
@@ -94,6 +94,8 @@ function ManureSystemPumpMotor.registerFunctions(vehicleType)
     SpecializationUtil.registerFunction(vehicleType, "setPumpMaxTime", ManureSystemPumpMotor.setPumpMaxTime)
     SpecializationUtil.registerFunction(vehicleType, "getPumpMaxTime", ManureSystemPumpMotor.getPumpMaxTime)
     SpecializationUtil.registerFunction(vehicleType, "getOriginalPumpMaxTime", ManureSystemPumpMotor.getOriginalPumpMaxTime)
+    SpecializationUtil.registerFunction(vehicleType, "getCanDisableVanillaUnloading", ManureSystemPumpMotor.getCanDisableVanillaUnloading)
+    SpecializationUtil.registerFunction(vehicleType, "getCanDisableVanillaLoading", ManureSystemPumpMotor.getCanDisableVanillaLoading)
 end
 
 ---@return void
@@ -214,12 +216,6 @@ function ManureSystemPumpMotor.disableDischargeable(self)
                 removeTrigger(dischargeNode.trigger.node)
             end
         end
-    end
-
-    local spec_fillTriggerVehicle = self.spec_fillTriggerVehicle
-    if spec_fillTriggerVehicle ~= nil and spec_fillTriggerVehicle.fillTrigger ~= nil then
-        spec_fillTriggerVehicle.fillTrigger:delete()
-        spec_fillTriggerVehicle.fillTrigger = nil
     end
 end
 
@@ -898,6 +894,24 @@ end
 ---@return number
 function ManureSystemPumpMotor:getPumpMaxTime()
     return self.spec_manureSystemPumpMotor.pumpEfficiency.maxTime
+end
+
+---@return boolean
+function ManureSystemPumpMotor:getCanDisableVanillaUnloading(sourceObject, trigger)
+    if self:getIsAIActive() then
+        return false
+    end
+
+    return true
+end
+
+---@return boolean
+function ManureSystemPumpMotor:getCanDisableVanillaLoading(targetObject, trigger)
+    if self:getIsAIActive() then
+        return false
+    end
+
+    return true
 end
 
 ----------------

--- a/src/vehicles/specializations/ManureSystemPumpMotor.lua
+++ b/src/vehicles/specializations/ManureSystemPumpMotor.lua
@@ -454,7 +454,7 @@ end
 ---Prints debug information of the source/target object, if pumping is not allowed.
 ---@return void
 local function debugPumpNotAllowedWarning(self, message, sourceObject, sourceFillUnitIndex, targetObject, targetFillUnitIndex)
-    if g_currentMission.manureSystem.debug then
+    if g_currentMission.manureSystem.debug and g_showDevelopmentWarnings then
         Logging.warning("Pumping is not allowed. Reason: %s", message)
 
         local sourceObjectName = sourceObject ~= nil and sourceObject:getName() or nil


### PR DESCRIPTION
If the manure system debug is enabled and pumping is not allowed, information of the source/target object will be printed into the log file. This is helpful, if someone experiences unexpected behavior after adding manure system to vehicles or placeables.