### PR TITLE
Fix: prefent to crach game in build mode

### DIFF
--- a/src/placeables/specializations/ManureSystemPlaceableMixers.lua
+++ b/src/placeables/specializations/ManureSystemPlaceableMixers.lua
@@ -175,8 +175,10 @@ end
 
 ---@return void
 function ManureSystemPlaceableMixers:onDelete()
-    for _, mixer in ipairs(self.spec_manureSystemPlaceableMixers.mixers) do
-        self:unloadMixer(mixer)
+    if self.spec_manureSystemPlaceableMixers ~= nil and self.spec_manureSystemPlaceableMixers.mixers ~= nil then
+        for _, mixer in ipairs(self.spec_manureSystemPlaceableMixers.mixers) do
+            self:unloadMixer(mixer)
+        end
     end
 end
 


### PR DESCRIPTION
Add nil checks for manure system mixers to prevent crash in onDelete

- Added checks to ensure spec_manureSystemPlaceableMixers and its mixers table are not nil before attempting to unload mixers.
- This prevents potential crashes caused by attempting to iterate over a nil table.

#201 